### PR TITLE
Create Zelda 64.psm1

### DIFF
--- a/Files/Scripts/Zelda 64.psm1
+++ b/Files/Scripts/Zelda 64.psm1
@@ -507,13 +507,15 @@ function ShowHudPreview([switch]$IsOoT) {
     $file = $null
     if       ( ( (IsChecked $Redux.UI.Rupees)      -or (IsChecked $Redux.UI.HUD) )      -and  $IsOoT)        { $file = "Majora's Mask"   }
     elseif   ( ( (IsChecked $Redux.UI.Rupees)      -or (IsChecked $Redux.UI.HUD) )      -and !$IsOoT)        { $file = "Ocarina of Time" }
-    elseif   ( ( (IsChecked $Redux.UI.Rupees -Not) -or (IsChecked $Redux.UI.HUD -Not) ) -and  $IsOoT)        { $file = "Ocarina of Time" }    elseif   ( ( (IsChecked $Redux.UI.Rupees -Not) -or (IsChecked $Redux.UI.HUD -Not) ) -and !$IsOoT)        { $file = "Majora's Mask"   }
+    elseif   ( ( (IsChecked $Redux.UI.Rupees -Not) -or (IsChecked $Redux.UI.HUD -Not) ) -and  $IsOoT)        { $file = "Ocarina of Time" }
+    elseif   ( ( (IsChecked $Redux.UI.Rupees -Not) -or (IsChecked $Redux.UI.HUD -Not) ) -and !$IsOoT)        { $file = "Majora's Mask"   }
     if (TestFile ($Paths.Shared + "\HUD\Rupees\" + $file + ".png"))    { SetBitMap -Path ($Paths.Shared + "\HUD\Rupees\" + $file + ".png") -Box $Redux.UI.RupeesPreview } else { $Redux.UI.RupeesPreview.Image = $null }
 
     $file = $null
     if       ( ( (IsChecked $Redux.UI.DungeonKeys)      -or (IsChecked $Redux.UI.HUD) )      -and  $IsOoT)        { $file = "Majora's Mask"   }
     elseif   ( ( (IsChecked $Redux.UI.DungeonKeys)      -or (IsChecked $Redux.UI.HUD) )      -and !$IsOoT)        { $file = "Ocarina of Time" }
-    elseif   ( ( (IsChecked $Redux.UI.DungeonKeys -Not) -or (IsChecked $Redux.UI.HUD -Not) ) -and  $IsOoT)        { $file = "Ocarina of Time" }    elseif   ( ( (IsChecked $Redux.UI.DungeonKeys -Not) -or (IsChecked $Redux.UI.HUD -Not) ) -and !$IsOoT)        { $file = "Majora's Mask"   }
+    elseif   ( ( (IsChecked $Redux.UI.DungeonKeys -Not) -or (IsChecked $Redux.UI.HUD -Not) ) -and  $IsOoT)        { $file = "Ocarina of Time" }
+    elseif   ( ( (IsChecked $Redux.UI.DungeonKeys -Not) -or (IsChecked $Redux.UI.HUD -Not) ) -and !$IsOoT)        { $file = "Majora's Mask"   }
     if (TestFile ($Paths.Shared + "\HUD\Keys\"   + $file + ".png"))    { SetBitMap -Path ($Paths.Shared + "\HUD\Keys\"   + $file + ".png") -Box $Redux.UI.DungeonKeysPreview } else { $Redux.UI.DungeonKeysPreview.Image = $null }
 }
 
@@ -1197,8 +1199,8 @@ function SetFairyColorsPreset([object]$ComboBox, [Array]$Dialogs, [Array]$Labels
     
     $Text = $ComboBox.Text.replace(' (default)', "")
     if     ($Text -eq "Navi")                { SetFairyColors -Inner "FFFFFF" -Outer "0000FF" -Dialogs $Dialogs -Labels $Labels }
-    elseif ($Text -eq "Tatl")                { SetFairyColors -Inner "FFFFE6" -Outer "DCA050" -Dialogs $Dialogs -Labels $Labels }
-    elseif ($Text -eq "Tael")                { SetFairyColors -Inner "49146C" -Outer "FF0000" -Dialogs $Dialogs -Labels $Labels }
+    elseif ($Text -eq "Tatl")                { SetFairyColors -Inner "FAFFE6" -Outer "DCA050" -Dialogs $Dialogs -Labels $Labels }
+    elseif ($Text -eq "Tael")                { SetFairyColors -Inner "3F125D" -Outer "FA280A" -Dialogs $Dialogs -Labels $Labels }
     elseif ($Text -eq "Gold")                { SetFairyColors -Inner "FECC3C" -Outer "FEC007" -Dialogs $Dialogs -Labels $Labels }
     elseif ($Text -eq "Green")               { SetFairyColors -Inner "00FF00" -Outer "00FF00" -Dialogs $Dialogs -Labels $Labels }
     elseif ($Text -eq "Light Blue")          { SetFairyColors -Inner "9696FF" -Outer "9696FF" -Dialogs $Dialogs -Labels $Labels }


### PR DESCRIPTION
Values taken directly from the z_dm_char00 overlay, which hosts the RGB values for both Tatl and Tael in cutscenes, and to match also the z_en_elf overlay's values for Tatl.