### PR TITLE
Added new fixes and a new option

### DIFF
--- a/Files/Scripts/Options/Ocarina of Time.psm1
+++ b/Files/Scripts/Options/Ocarina of Time.psm1
@@ -1884,10 +1884,6 @@ function ByteSceneOptions() {
         ChangeSceneFile -Values "24" -Search "0000000400000FC80000000400000FCA" # 202043C
         SaveAndPatchLoadedScene
     }
-
-    if (IsChecked $Redux.Fixes.UselessMagicJar) {
-        PrepareMap -Scene "Gerudo Training Ground" -Map 4 -Header 0; ReplaceActor -Name "Invisible Collectable" -Compare "1093" -Y (-1000) -Z (-4000); SaveAndPatchLoadedScene
-    }
     
     if (IsChecked $Redux.Fixes.TimeDoor) {
         for ($i=0; $i -le 11; $i++) { PrepareMap -Scene "Temple of Time" -Map 1 -Header $i; ReplaceActor -Name "Temple of Time" -Compare "000D" -X "FFFC" }
@@ -1895,7 +1891,7 @@ function ByteSceneOptions() {
     }
 
     if (IsChecked $Redux.Fixes.GerudosFortress) { PrepareMap -Scene "Gerudo's Fortress" -Map 0 -Header 0; ReplaceActor -Name "Treasure Chest" -Compare "03E0" -Param "07C0"; SaveAndPatchLoadedScene }
-    
+   
     if (IsChecked $Redux.Fixes.Dungeons) {
         PrepareMap   -Scene "Dodongo's Cavern" -Map 0 -Header 0
         ReplaceActor -Name "Gossip Stone" -Compare "1114" -Param "1138"
@@ -1917,7 +1913,8 @@ function ByteSceneOptions() {
         PrepareMap -Scene "Fire Temple"   -Map 13 -Header 0; ReplaceActor -Name "Navi Message"     -Compare "BFA7" -Y 4171  -YRot 22;               SaveAndPatchLoadedScene
         PrepareMap -Scene "Ice Cavern"    -Map 3  -Header 0; ReplaceActor -Name "Navi Message"     -Compare "0580" -XRot 24 -YRot 0 -ZRot 0;        SaveAndPatchLoadedScene
         PrepareMap -Scene "Shadow Temple" -Map 21 -Header 0; ReplaceActor -Name "Information Spot" -Compare "2084" -X (-2724) -Y (-1293) -Z (-596); SaveAndPatchLoadedScene
-        PrepareMap -Scene "Spirit Temple" -Map 5  -Header 0; ReplaceActor -Name "Information Spot" -Compare "3C24" -Z (-1410);                      SaveAndPatchLoadedScene
+        PrepareMap -Scene "Gerudo Training Ground" -Map 4 -Header 0; ReplaceActor -Name "Invisible Collectable" -Compare "1093" -Y (-1000) -Z (-4000); SaveAndPatchLoadedScene
+	PrepareMap -Scene "Spirit Temple" -Map 5  -Header 0; ReplaceActor -Name "Information Spot" -Compare "3C24" -Z (-1410);                      SaveAndPatchLoadedScene
     }
 
     if (IsChecked $Redux.Fixes.GreatFairyTextBoxes) {
@@ -2789,10 +2786,9 @@ function CreateTabMain() {
     CreateReduxCheckBox -Name "VisibleGerudoTent"         -Base 4 -Child -Text "Visible Gerudo Tent"       -Info "Make the tent in Gerudo Valley during the Child era visible`nThe tent was always accessible, just invisible"                              -Exclude "Child" -Credits "Admentus"
     CreateReduxCheckBox -Name "Graves"                    -Base 4 -Safe  -Text "Graveyard Graves"          -Info "The grave holes in Kakariko Graveyard behave as in the Rev 1 revision`nThe edges no longer force Link to grab or jump over them when trying to enter"      -Credits "Admentus"
     CreateReduxCheckBox -Name "TimeDoor"                  -Base 4 -Safe  -Text "Fix Door of Time"          -Info "Fix the positioning of the Temple of Time door, so you can not skip past it`nAlso fixes a bug where the door doesn't open on your first visit"             -Credits "Admentus & Randomizer"
-    $text = "Fix issues in Dodogono's Cavern, Water Temple and Spirit Temple`n`n- Gossip Stones that won't spawn fairies (Dodongo's Cavern)`n- Unreachable hookshot spot (Raging Water Cavern)`n- Three out of bounds pots (Raging Water Cavern)`n- Restore two Keese (Central Hall)"
-    CreateReduxCheckBox -Name "Dungeons"                  -Base 4 -Safe  -Text "Fix Dungeons"              -Info ($text + "`n- Navi targeting Spots in Fire Temple, Ice Cavern, Shadow Temple and Spirit Temple" )                                    -Exclude "Child Quest" -Credits "Admentus, ZethN64, Sakura, Frostclaw, Steve(ToCoool) & GhostlyDark (ported)"
+    $text = "Fix issues in Dodogono's Cavern, Water Temple and Spirit Temple`n`n- Gossip Stones that won't spawn fairies (Dodongo's Cavern)`n- Unreachable hookshot spot (Raging Water Cavern)`n- Three out of bounds pots (Raging Water Cavern)`n- Restore two Keese (Central Hall)`n- Removes the non-functional Magic Jar atop the Statues in Gerudo Training Ground (Statues Challenge)"
+    CreateReduxCheckBox -Name "Dungeons"                  -Base 4 -Safe  -Text "Fix Dungeons"              -Info ($text + "`n- Navi targeting Spots in Fire Temple, Ice Cavern, Shadow Temple and Spirit Temple" )                                    -Exclude "Child Quest" -Credits "Admentus, ZethN64, Sakura, Frostclaw, Steve(ToCoool), GoldenMariaNova & GhostlyDark (ported)"
     CreateReduxCheckBox -Name "GreatFairyTextBoxes"       -Base 4 -Safe  -Text "Fix Great Fairy Textboxes" -Info "Fix the broken textboxes outside the Great Fairy entrances in Death Mountain Crater and Desert Colossus"                                                   -Credits "Admentus"
-    CreateReduxCheckBox -Name "UselessMagicJar"           -Base 4        -Text "Remove Useless Jar"        -Info "Removes the non-functional Magic Jar atop the Statues in Gerudo Training Ground"                                                                           -Credits "GoldenMariaNova"
 
 
     # OTHER #

--- a/Files/Scripts/Options/Ocarina of Time.psm1
+++ b/Files/Scripts/Options/Ocarina of Time.psm1
@@ -1885,6 +1885,10 @@ function ByteSceneOptions() {
         SaveAndPatchLoadedScene
     }
 
+    if (IsChecked $Redux.Fixes.UselessMagicJar) {
+        PrepareMap -Scene "Gerudo Training Ground" -Map 4 -Header 0; ReplaceActor -Name "Invisible Collectable" -Compare "1093" -Y (-1000) -Z (-4000); SaveAndPatchLoadedScene
+    }
+    
     if (IsChecked $Redux.Fixes.TimeDoor) {
         for ($i=0; $i -le 11; $i++) { PrepareMap -Scene "Temple of Time" -Map 1 -Header $i; ReplaceActor -Name "Temple of Time" -Compare "000D" -X "FFFC" }
         SaveAndPatchLoadedScene
@@ -2216,10 +2220,10 @@ function ByteTextOptions() {
         SetMessage -ID "00BE" -Text "man"      -Replace "lady";       SetMessage -ID "0168"; SetMessage -ID "021C";      SetMessage -ID "2025"; SetMessage -ID "2030"; SetMessage -ID "2037"; SetMessage -ID "2085"; SetMessage -ID "407D"; SetMessage -ID "4088"; SetMessage -ID "502D"
         SetMessage -ID "502E";                                        SetMessage -ID "5041"; SetMessage -ID "505B" -All; SetMessage -ID "5081"; SetMessage -ID "6066"; SetMessage -ID "7011"; SetMessage -ID "70F4"; SetMessage -ID "70F5"; SetMessage -ID "70F7"; SetMessage -ID "70F8"
 
-        SetMessage -ID "6035" -Text "man"      -Replace "woman";      SetMessage -ID "70A1"
+        SetMessage -ID "70A1" -Text "man"      -Replace "woman"
         SetMessage -ID "102F" -Text "real man" -Replace "real woman"; SetMessage -ID "10D7"; SetMessage -ID "301C"; SetMessage -ID "301D"; SetMessage -ID "303C"
         SetMessage -ID "301E" -Text "Brother"  -Replace "Sister";     SetMessage -ID "3027"; SetMessage -ID "3039"; SetMessage -ID "303C"; SetMessage -ID "3041"; SetMessage -ID "3045"; SetMessage -ID "3046"; SetMessage -ID "3068" -All
-        SetMessage -ID "3006" -Text "brother"  -Replace "sister";     SetMessage -ID "70E1"
+        SetMessage -ID "3006" -Text "brother"  -Replace "Sister";     SetMessage -ID "70E1"
         SetMessage -ID "3000" -Text "Brother"  -Replace "Sibling";    SetMessage -ID "3001"; SetMessage -ID "3004"; SetMessage -ID "303D"
         SetMessage -ID "102F" -Text "Mr."      -Replace "Ms.";        SetMessage -ID "200A"; SetMessage -ID "2010"; SetMessage -ID "2011"; SetMessage -ID "2015"; SetMessage -ID "2020"; SetMessage -ID "5068"; SetMessage -ID "712D"
         SetMessage -ID "4018" -Text "son"      -Replace "lass";       SetMessage -ID "5063"; SetMessage -ID "5066"
@@ -2787,8 +2791,8 @@ function CreateTabMain() {
     CreateReduxCheckBox -Name "TimeDoor"                  -Base 4 -Safe  -Text "Fix Door of Time"          -Info "Fix the positioning of the Temple of Time door, so you can not skip past it`nAlso fixes a bug where the door doesn't open on your first visit"             -Credits "Admentus & Randomizer"
     $text = "Fix issues in Dodogono's Cavern, Water Temple and Spirit Temple`n`n- Gossip Stones that won't spawn fairies (Dodongo's Cavern)`n- Unreachable hookshot spot (Raging Water Cavern)`n- Three out of bounds pots (Raging Water Cavern)`n- Restore two Keese (Central Hall)"
     CreateReduxCheckBox -Name "Dungeons"                  -Base 4 -Safe  -Text "Fix Dungeons"              -Info ($text + "`n- Navi targeting Spots in Fire Temple, Ice Cavern, Shadow Temple and Spirit Temple" )                                    -Exclude "Child Quest" -Credits "Admentus, ZethN64, Sakura, Frostclaw, Steve(ToCoool) & GhostlyDark (ported)"
-    CreateReduxCheckBox -Name "GreatFairyTextBoxes"       -Base 4 -Safe  -Text "Fix Great Fairy Textboxes" -Info 'Fix the broken textboxes outside the Great Fairy entrances in Death Mountain Crater and Desert Colossus'                                                   -Credits "Admentus"
-
+    CreateReduxCheckBox -Name "GreatFairyTextBoxes"       -Base 4 -Safe  -Text "Fix Great Fairy Textboxes" -Info "Fix the broken textboxes outside the Great Fairy entrances in Death Mountain Crater and Desert Colossus"                                                   -Credits "Admentus"
+    CreateReduxCheckBox -Name "UselessMagicJar"           -Base 4        -Text "Remove Useless Jar"        -Info "Removes the non-functional Magic Jar atop the Statues in Gerudo Training Ground"                                                                           -Credits "GoldenMariaNova"
 
 
     # OTHER #
@@ -2966,7 +2970,7 @@ function CreateTabLanguage() {
         $last.Column = 1; $last.Row++
     }
 
-    CreateReduxCheckBox -Base 1 -Name "Restore"        -Safe -Text "Restore Text"    -Info "Restores the text used from the GC revision and applies grammar & typo fixes and corrects some icons in the text"                                          -Credits "Admentus & ShadowOne333"
+    CreateReduxCheckBox -Base 1 -Name "Restore"        -Safe -Text "Restore Text"    -Info "Restores the text used from the GC and later revisions and applies their text and icons fixes in the game dialogue"                                        -Credits "Admentus & ShadowOne333"
     CreateReduxCheckBox -Base 1 -Name "FemalePronouns" -Safe -Text "Female Pronouns" -Info "Refer to Link as a female character"                                                                                                                       -Credits "Admentus"
     CreateReduxCheckBox -Base 5 -Name "GoldSkulltula"  -Safe -Text "Gold Skulltula"  -Info "The textbox for obtaining a Gold Skulltula will no longer interrupt the gameplay`nThe English & German scripts also shows the total amount you got so far" -Credits "ShadowOne333"
     CreateReduxCheckBox -Base 4 -Name "EasterEggs"     -Safe -Text "Easter Eggs"     -Info "Adds custom Patreon Tier 3 messages into the game`nCan you find them all?" -Checked                                                                        -Credits "Admentus & Patreons"


### PR DESCRIPTION
Ok, there's the list of changes : 
**1**. A new option have been added, which is about the non-functional **Magic Jar** atop the cyclops statues in **Gerudo Training Ground**. Basically "_removing_" it by making it inaccessible instead of outright really removing it, thus preventing excessive code shifting.

**2**. Removed a duplicate in the **Feminine Pronouns** script. Also a very tiny change on another.

**3**. Changed the info of the **Restore Text** option, reflecting more on what it changes after the latest fixes, which is way more than changing some text based on the **GC** release now.

That's should be all.