### PR TITLE
Simple Aesthetic Addon

### DIFF
--- a/Files/Scripts/MQ.psm1
+++ b/Files/Scripts/MQ.psm1
@@ -2,6 +2,10 @@ function PatchDungeonsOoTMQ() {
     
     if ($GameType.mode -ne "Ocarina of Time") { return }
 
+    if (IsIndex -Elem $Redux.MQ.Logo -Text "Vanilla + GC Copyright") { # The GC copyright is the same as OOT Master Quest, as they are on the same disk
+        PatchBytes -Offset "17AE300" -Texture -Patch "Logo\mq_copyright.bin" 
+    }
+
     if (IsIndex -Elem $Redux.MQ.Logo -Text "Master Quest") { # MQ Title with Subtitle
         PatchBytes -Offset "1795300" -Texture -Patch "Logo\mq_logo.bin"
         PatchBytes -Offset "17AE300" -Texture -Patch "Logo\mq_copyright.bin"


### PR DESCRIPTION
It just add what the **Master Quest** re-release original version of **OOT** had as a copyright, since the re-release on **GC** was in 2003. They share the same years markers.

Nothing else. It's just aesthetic and harmless.

I also had to modify **Ocarina of time.psm1**. Sorry for the inconvenience.